### PR TITLE
fix: Installer post-install launch fails with error 740

### DIFF
--- a/extras/Winhance.Installer.iss
+++ b/extras/Winhance.Installer.iss
@@ -250,7 +250,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: re
 ; Install .NET 10 Runtime (always for regular installation, optional for portable)
 Filename: "{tmp}\{#DotNetRuntimeInstallerName}"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing .NET 10 Runtime..."; Flags: waituntilterminated; Check: ShouldInstallDotNetRuntime
 ; Launch application after installation
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: shellexec nowait postinstall skipifsilent
 
 [UninstallDelete]
 ; Delete all files and directories that might remain after uninstallation


### PR DESCRIPTION
## Summary
- Add `shellexec` flag to the post-install `[Run]` entry in the Inno Setup script so `ShellExecute` is used instead of `CreateProcess`, which properly triggers UAC elevation for the `requireAdministrator` manifest.

## Test plan
- [ ] Build installer and run it as admin
- [ ] Select "Launch Winhance" checkbox on finish and verify the app launches without error 740