### PR TITLE
fix: add 25H2-compatible registry key for Bing Search in Start Menu

### DIFF
--- a/src/Winhance.Core/Features/Customize/Models/StartMenuCustomizations.cs
+++ b/src/Winhance.Core/Features/Customize/Models/StartMenuCustomizations.cs
@@ -379,6 +379,18 @@ public static class StartMenuCustomizations
                             ValueType = RegistryValueKind.DWord,
                             IsGroupPolicy = true,
                         },
+                        new RegistrySetting
+                        {
+                            // Required for Windows 11 25H2+ where the redesigned Start Menu
+                            // consults this user-preference key independently of the Group Policy entries above.
+                            KeyPath = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Search",
+                            ValueName = "BingSearchEnabled",
+                            RecommendedValue = 0,
+                            EnabledValue = [1, null],
+                            DisabledValue = [0],
+                            DefaultValue = 1,
+                            ValueType = RegistryValueKind.DWord,
+                        },
                     },
                 },
             },


### PR DESCRIPTION
## Summary

- Windows 11 25H2 introduced a redesigned Start Menu that consults `BingSearchEnabled` under `HKCU\Software\Microsoft\Windows\CurrentVersion\Search` independently of the existing Group Policy `DisableSearchBoxSuggestions` keys.
- The toggle was silently no-op on 25H2 because only the GP keys were being set, which the new Start Menu appears to ignore (or treats as insufficient alone).
- Added `BingSearchEnabled = 0` as a third `RegistrySetting` on the existing `start-disable-bing-search-results` definition. Toggle-OFF sets it to `0`; toggle-ON restores it to `1` (or deletes it).

## Behaviour

| Build | Before fix | After fix |
|---|---|---|
| Pre-25H2 | DisableSearchBoxSuggestions worked | Same — GP keys still applied |
| 25H2+ | Toggle had no visible effect | BingSearchEnabled covers the gap |

Fixes #589

## Test plan

- [ ] On Windows 11 25H2 (build 26200+): toggle "Bing Search Results in Start Menu" OFF, restart Explorer / sign out → verify Bing results no longer appear in Start
- [ ] Toggle it back ON → verify Bing results return
- [ ] On an older build (23H2/24H2): confirm toggle still works as before (no regression)