### PR TITLE
fix: add accessible names to setting buttons and WimUtils keyboard nav (#597)

### DIFF
--- a/src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml
+++ b/src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml
@@ -107,9 +107,14 @@
                     CornerRadius="4">
                 <StackPanel>
                     <!-- Step 1 Header -->
-                    <Border Padding="16,12"
-                            Tapped="Step1_Header_Tapped"
-                            Background="Transparent">
+                    <Button Padding="16,12"
+                            Command="{x:Bind ViewModel.NavigateToStepCommand}"
+                            CommandParameter="1"
+                            AutomationProperties.Name="{x:Bind ViewModel.Step1State.Title, Mode=OneWay}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            Background="Transparent"
+                            BorderThickness="0">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -160,7 +165,7 @@
                                 </fluentIcons:SymbolIcon.RenderTransform>
                             </fluentIcons:SymbolIcon>
                         </Grid>
-                    </Border>
+                    </Button>
 
                     <!-- Step 1 Content -->
                     <StackPanel Visibility="{x:Bind ViewModel.Step1State.IsExpanded, Mode=OneWay}"
@@ -337,9 +342,14 @@
                 <Grid>
                     <StackPanel>
                         <!-- Step 2 Header -->
-                        <Border Padding="16,12"
-                                Tapped="Step2_Header_Tapped"
-                                Background="Transparent">
+                        <Button Padding="16,12"
+                                Command="{x:Bind ViewModel.NavigateToStepCommand}"
+                                CommandParameter="2"
+                                AutomationProperties.Name="{x:Bind ViewModel.Step2State.Title, Mode=OneWay}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderThickness="0">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -393,7 +403,7 @@
                                     </fluentIcons:SymbolIcon.RenderTransform>
                                 </fluentIcons:SymbolIcon>
                             </Grid>
-                        </Border>
+                        </Button>
 
                         <!-- Step 2 Content -->
                         <StackPanel Visibility="{x:Bind ViewModel.Step2State.IsExpanded, Mode=OneWay}"
@@ -502,9 +512,14 @@
                 <Grid>
                     <StackPanel>
                         <!-- Step 3 Header -->
-                        <Border Padding="16,12"
-                                Tapped="Step3_Header_Tapped"
-                                Background="Transparent">
+                        <Button Padding="16,12"
+                                Command="{x:Bind ViewModel.NavigateToStepCommand}"
+                                CommandParameter="3"
+                                AutomationProperties.Name="{x:Bind ViewModel.Step3State.Title, Mode=OneWay}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderThickness="0">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -555,7 +570,7 @@
                                     </fluentIcons:SymbolIcon.RenderTransform>
                                 </fluentIcons:SymbolIcon>
                             </Grid>
-                        </Border>
+                        </Button>
 
                         <!-- Step 3 Content -->
                         <StackPanel Visibility="{x:Bind ViewModel.Step3State.IsExpanded, Mode=OneWay}"
@@ -588,9 +603,14 @@
                 <Grid>
                     <StackPanel>
                         <!-- Step 4 Header -->
-                        <Border Padding="16,12"
-                                Tapped="Step4_Header_Tapped"
-                                Background="Transparent">
+                        <Button Padding="16,12"
+                                Command="{x:Bind ViewModel.NavigateToStepCommand}"
+                                CommandParameter="4"
+                                AutomationProperties.Name="{x:Bind ViewModel.Step4State.Title, Mode=OneWay}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Background="Transparent"
+                                BorderThickness="0">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -644,7 +664,7 @@
                                     </fluentIcons:SymbolIcon.RenderTransform>
                                 </fluentIcons:SymbolIcon>
                             </Grid>
-                        </Border>
+                        </Button>
 
                         <!-- Step 4 Content -->
                         <StackPanel Visibility="{x:Bind ViewModel.Step4State.IsExpanded, Mode=OneWay}"

--- a/src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml.cs
+++ b/src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using Winhance.UI.Features.AdvancedTools.ViewModels;
@@ -48,26 +47,6 @@ public sealed partial class WimUtilPage : Page
 
         // Initialize the ViewModel
         await ViewModel.OnNavigatedToAsync();
-    }
-
-    private void Step1_Header_Tapped(object sender, TappedRoutedEventArgs e)
-    {
-        ViewModel.NavigateToStepCommand.Execute("1");
-    }
-
-    private void Step2_Header_Tapped(object sender, TappedRoutedEventArgs e)
-    {
-        ViewModel.NavigateToStepCommand.Execute("2");
-    }
-
-    private void Step3_Header_Tapped(object sender, TappedRoutedEventArgs e)
-    {
-        ViewModel.NavigateToStepCommand.Execute("3");
-    }
-
-    private void Step4_Header_Tapped(object sender, TappedRoutedEventArgs e)
-    {
-        ViewModel.NavigateToStepCommand.Execute("4");
     }
 
     private void Windows10Download_Click(object sender, RoutedEventArgs e)

--- a/src/Winhance.UI/Features/Common/Controls/SettingsCardItem.xaml
+++ b/src/Winhance.UI/Features/Common/Controls/SettingsCardItem.xaml
@@ -33,14 +33,16 @@
                     <Button
                         Style="{StaticResource QuickSetRecommendedButtonStyle}"
                         Command="{x:Bind SetToggleToRecommendedCommand}"
-                        ToolTipService.ToolTip="{x:Bind ToggleRecommendedTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind ToggleRecommendedTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ToggleRecommendedTooltip, Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                   Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                     </Button>
                     <Button
                         Style="{StaticResource QuickSetDefaultButtonStyle}"
                         Command="{x:Bind SetToggleToDefaultCommand}"
-                        ToolTipService.ToolTip="{x:Bind ToggleDefaultTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind ToggleDefaultTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ToggleDefaultTooltip, Mode=OneWay}">
                         <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                   Foreground="{ThemeResource BadgeDefaultForeground}"/>
                     </Button>
@@ -61,14 +63,16 @@
                     <Button
                         Style="{StaticResource QuickSetRecommendedButtonStyle}"
                         Command="{x:Bind SetSelectionToRecommendedCommand}"
-                        ToolTipService.ToolTip="{x:Bind SelectionRecommendedTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind SelectionRecommendedTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind SelectionRecommendedTooltip, Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                   Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                     </Button>
                     <Button
                         Style="{StaticResource QuickSetDefaultButtonStyle}"
                         Command="{x:Bind SetSelectionToDefaultCommand}"
-                        ToolTipService.ToolTip="{x:Bind SelectionDefaultTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind SelectionDefaultTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind SelectionDefaultTooltip, Mode=OneWay}">
                         <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                   Foreground="{ThemeResource BadgeDefaultForeground}"/>
                     </Button>
@@ -100,14 +104,16 @@
                     <Button
                         Style="{StaticResource QuickSetRecommendedButtonStyle}"
                         Command="{x:Bind SetNumericToRecommendedCommand}"
-                        ToolTipService.ToolTip="{x:Bind RecommendedValueTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind RecommendedValueTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind RecommendedValueTooltip, Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                   Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                     </Button>
                     <Button
                         Style="{StaticResource QuickSetDefaultButtonStyle}"
                         Command="{x:Bind SetNumericToDefaultCommand}"
-                        ToolTipService.ToolTip="{x:Bind DefaultValueTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind DefaultValueTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind DefaultValueTooltip, Mode=OneWay}">
                         <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                   Foreground="{ThemeResource BadgeDefaultForeground}"/>
                     </Button>
@@ -150,14 +156,16 @@
                             <Button
                                 Style="{StaticResource QuickSetRecommendedButtonStyle}"
                                 Command="{x:Bind SetAcSelectionToRecommendedCommand}"
-                                ToolTipService.ToolTip="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                           Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                             </Button>
                             <Button
                                 Style="{StaticResource QuickSetDefaultButtonStyle}"
                                 Command="{x:Bind SetAcSelectionToDefaultCommand}"
-                                ToolTipService.ToolTip="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}">
                                 <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                           Foreground="{ThemeResource BadgeDefaultForeground}"/>
                             </Button>
@@ -178,14 +186,16 @@
                             <Button
                                 Style="{StaticResource QuickSetRecommendedButtonStyle}"
                                 Command="{x:Bind SetDcSelectionToRecommendedCommand}"
-                                ToolTipService.ToolTip="{x:Bind DcSelectionRecommendedTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind DcSelectionRecommendedTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind DcSelectionRecommendedTooltip, Mode=OneWay}">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                           Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                             </Button>
                             <Button
                                 Style="{StaticResource QuickSetDefaultButtonStyle}"
                                 Command="{x:Bind SetDcSelectionToDefaultCommand}"
-                                ToolTipService.ToolTip="{x:Bind DcSelectionDefaultTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind DcSelectionDefaultTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind DcSelectionDefaultTooltip, Mode=OneWay}">
                                 <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                           Foreground="{ThemeResource BadgeDefaultForeground}"/>
                             </Button>
@@ -209,14 +219,16 @@
                     <Button
                         Style="{StaticResource QuickSetRecommendedButtonStyle}"
                         Command="{x:Bind SetAcSelectionToRecommendedCommand}"
-                        ToolTipService.ToolTip="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind AcSelectionRecommendedTooltip, Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                   Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                     </Button>
                     <Button
                         Style="{StaticResource QuickSetDefaultButtonStyle}"
                         Command="{x:Bind SetAcSelectionToDefaultCommand}"
-                        ToolTipService.ToolTip="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind AcSelectionDefaultTooltip, Mode=OneWay}">
                         <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                   Foreground="{ThemeResource BadgeDefaultForeground}"/>
                     </Button>
@@ -241,14 +253,16 @@
                             <Button
                                 Style="{StaticResource QuickSetRecommendedButtonStyle}"
                                 Command="{x:Bind SetAcNumericToRecommendedCommand}"
-                                ToolTipService.ToolTip="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                           Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                             </Button>
                             <Button
                                 Style="{StaticResource QuickSetDefaultButtonStyle}"
                                 Command="{x:Bind SetAcNumericToDefaultCommand}"
-                                ToolTipService.ToolTip="{x:Bind DefaultAcValueTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind DefaultAcValueTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind DefaultAcValueTooltip, Mode=OneWay}">
                                 <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                           Foreground="{ThemeResource BadgeDefaultForeground}"/>
                             </Button>
@@ -272,14 +286,16 @@
                             <Button
                                 Style="{StaticResource QuickSetRecommendedButtonStyle}"
                                 Command="{x:Bind SetDcNumericToRecommendedCommand}"
-                                ToolTipService.ToolTip="{x:Bind RecommendedDcValueTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind RecommendedDcValueTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind RecommendedDcValueTooltip, Mode=OneWay}">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                           Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                             </Button>
                             <Button
                                 Style="{StaticResource QuickSetDefaultButtonStyle}"
                                 Command="{x:Bind SetDcNumericToDefaultCommand}"
-                                ToolTipService.ToolTip="{x:Bind DefaultDcValueTooltip, Mode=OneWay}">
+                                ToolTipService.ToolTip="{x:Bind DefaultDcValueTooltip, Mode=OneWay}"
+                                AutomationProperties.Name="{x:Bind DefaultDcValueTooltip, Mode=OneWay}">
                                 <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                           Foreground="{ThemeResource BadgeDefaultForeground}"/>
                             </Button>
@@ -306,14 +322,16 @@
                     <Button
                         Style="{StaticResource QuickSetRecommendedButtonStyle}"
                         Command="{x:Bind SetAcNumericToRecommendedCommand}"
-                        ToolTipService.ToolTip="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind RecommendedAcValueTooltip, Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE735;" FontSize="14"
                                   Foreground="{ThemeResource BadgeRecommendedForeground}"/>
                     </Button>
                     <Button
                         Style="{StaticResource QuickSetDefaultButtonStyle}"
                         Command="{x:Bind SetAcNumericToDefaultCommand}"
-                        ToolTipService.ToolTip="{x:Bind DefaultAcValueTooltip, Mode=OneWay}">
+                        ToolTipService.ToolTip="{x:Bind DefaultAcValueTooltip, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind DefaultAcValueTooltip, Mode=OneWay}">
                         <PathIcon Data="{StaticResource BadgeDefaultIconPath}" Height="12" Width="12"
                                   Foreground="{ThemeResource BadgeDefaultForeground}"/>
                     </Button>


### PR DESCRIPTION
## Summary

- **Quick-set buttons**: All 14 quick-set buttons (Recommended/Default) across the 7 input templates in `SettingsCardItem.xaml` were missing `AutomationProperties.Name`. Narrator announced them all as generic "button". Added `AutomationProperties.Name` bound to the same tooltip string already on each button — no new strings needed.
- **WimUtils step headers**: The 4 step section headers in `WimUtilPage.xaml` were non-interactive `Border` elements with `Tapped` event handlers. They were pointer-only; keyboard users had no way to expand/collapse steps. Replaced each with a `Button` (transparent, borderless, full-width) bound directly to `ViewModel.NavigateToStepCommand` with `CommandParameter="1"` through `"4"`. Removed the now-dead `StepN_Header_Tapped` code-behind handlers and the unused `TappedRoutedEventArgs` using directive.

## Files changed

- `src/Winhance.UI/Features/Common/Controls/SettingsCardItem.xaml` — 14 `AutomationProperties.Name` additions
- `src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml` — 4 Border → Button conversions
- `src/Winhance.UI/Features/AdvancedTools/WimUtilPage.xaml.cs` — removed 4 dead Tapped handlers + unused using

## Test plan

- [ ] Tab to any quick-set button on Optimize or Customize pages; Narrator should announce the button with its full tooltip text (e.g. "Set to Recommended: Enabled")
- [ ] Tab to each WimUtils step header; pressing Space/Enter should expand/collapse the step
- [ ] Verify pointer click on WimUtils step headers still works (command binding serves both)
- [ ] Verify no visual regression on the step headers (transparent background, borderless)

Fixes #597