### PR TITLE
fix: correct vertical description rendering in Power Multimedia (#601)

### DIFF
--- a/src/Winhance.UI/Features/Common/Controls/SettingDescriptionWithBadges.xaml
+++ b/src/Winhance.UI/Features/Common/Controls/SettingDescriptionWithBadges.xaml
@@ -2,7 +2,9 @@
 <UserControl
     x:Class="Winhance.UI.Features.Common.Controls.SettingDescriptionWithBadges"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    HorizontalAlignment="Stretch"
+    HorizontalContentAlignment="Stretch">
     <StackPanel Spacing="6">
         <TextBlock
             Text="{x:Bind DescriptionText, Mode=OneWay}"


### PR DESCRIPTION
## Root Cause

`SettingDescriptionWithBadges` is a `UserControl` placed inside `SettingsCard.Description`. In WinUI 3, `UserControl` (which inherits from `Control`) defaults `HorizontalContentAlignment` to `Left`, not `Stretch`. This means its implicit template `ContentPresenter` arranges the root `StackPanel` at its *desired* width rather than filling the available space.

When the UserControl is first measured with an empty `DescriptionText` (which happens during ListView virtualisation — e.g. when scrolling to the Multimedia Settings group), the `StackPanel` desired width is near-zero, so `SettingsCard` allocates near-zero column width for the description area. When the `DescriptionText` binding fires afterwards, the `TextBlock` re-measures but the column width remains constrained, causing `TextWrapping="Wrap"` to break each character onto its own line.

The previous inline-`StackPanel` implementation (before the `SettingDescriptionWithBadges` refactor in `10c1ee5d`) was not affected because `StackPanel` (a `Panel`) always stretches horizontally in its parent, regardless of `HorizontalContentAlignment`.

## Fix

Added `HorizontalAlignment="Stretch"` and `HorizontalContentAlignment="Stretch"` to the `SettingDescriptionWithBadges` `UserControl` declaration. This ensures:
- The UserControl itself stretches to fill the available SettingsCard description column width
- Its inner template ContentPresenter gives the root `StackPanel` the full UserControl width
- The description `TextBlock` wraps correctly at all column widths, including after virtualised items scroll into view

## Files Changed

- `src/Winhance.UI/Features/Common/Controls/SettingDescriptionWithBadges.xaml` — 2-line addition to `UserControl` element

## Test Plan

- [ ] Navigate to Optimize > Power, scroll down to the **Multimedia Settings** group
- [ ] Confirm "When Sharing Media", "Video Playback Quality Bias", and "When Playing Video" descriptions render horizontally on one or more lines (not one character per line)
- [ ] Scroll back to the top and confirm other Power settings (Display, Sleep, Processor Power Management etc.) still render correctly
- [ ] Resize the window to a narrow width and confirm descriptions wrap naturally rather than rendering vertically