### PR TITLE
fix: Hide Home/Gallery from Explorer nav pane on Windows 11 25H2

### DIFF
--- a/src/Winhance.Core/Features/Customize/Models/ExplorerCustomizations.cs
+++ b/src/Winhance.Core/Features/Customize/Models/ExplorerCustomizations.cs
@@ -1858,13 +1858,33 @@ if (Test-Path $appPathsKey) {
                     {
                         new RegistrySetting
                         {
-                            KeyPath = @"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
-                            ValueName = null,
-                            RecommendedValue = null,
-                            EnabledValue = [null],
-                            DisabledValue = null,
+                            KeyPath = @"HKEY_CURRENT_USER\Software\Classes\CLSID\{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
+                            ValueName = "System.IsPinnedToNameSpaceTree",
+                            RecommendedValue = 0,
+                            EnabledValue = [1, null],
+                            DisabledValue = [0],
+                            DefaultValue = 0,
+                            ValueType = RegistryValueKind.DWord,
+                        },
+                        new RegistrySetting
+                        {
+                            KeyPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\NonEnum",
+                            ValueName = "{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
+                            RecommendedValue = 1,
+                            EnabledValue = [0, null],
+                            DisabledValue = [1, null],
                             DefaultValue = null,
-                            ValueType = RegistryValueKind.None,
+                            ValueType = RegistryValueKind.DWord,
+                        },
+                        new RegistrySetting
+                        {
+                            KeyPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
+                            ValueName = "HiddenByDefault",
+                            RecommendedValue = 1,
+                            EnabledValue = [0, null],
+                            DisabledValue = [1, null],
+                            DefaultValue = null,
+                            ValueType = RegistryValueKind.DWord,
                         },
                     },
                 },
@@ -1882,13 +1902,33 @@ if (Test-Path $appPathsKey) {
                     {
                         new RegistrySetting
                         {
-                            KeyPath = @"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
-                            ValueName = null,
-                            RecommendedValue = null,
-                            EnabledValue = [null],
-                            DisabledValue = null,
+                            KeyPath = @"HKEY_CURRENT_USER\Software\Classes\CLSID\{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
+                            ValueName = "System.IsPinnedToNameSpaceTree",
+                            RecommendedValue = 0,
+                            EnabledValue = [1, null],
+                            DisabledValue = [0],
+                            DefaultValue = 0,
+                            ValueType = RegistryValueKind.DWord,
+                        },
+                        new RegistrySetting
+                        {
+                            KeyPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\NonEnum",
+                            ValueName = "{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
+                            RecommendedValue = 1,
+                            EnabledValue = [0, null],
+                            DisabledValue = [1, null],
                             DefaultValue = null,
-                            ValueType = RegistryValueKind.None,
+                            ValueType = RegistryValueKind.DWord,
+                        },
+                        new RegistrySetting
+                        {
+                            KeyPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
+                            ValueName = "HiddenByDefault",
+                            RecommendedValue = 1,
+                            EnabledValue = [0, null],
+                            DisabledValue = [1, null],
+                            DefaultValue = null,
+                            ValueType = RegistryValueKind.DWord,
                         },
                     },
                 },


### PR DESCRIPTION
## Summary

Fixes #641 — on Windows 11 25H2 (build 26200.x), hiding the **Home** entry from File Explorer's navigation pane no longer sticks: after any file mutation in Explorer (e.g. deleting a folder), Home reappears at the bottom of the pane until the window is closed and reopened.

## Root cause

The previous "Show Home Folder" / "Show Gallery" settings hid these items by **deleting** the `HKLM\…\Explorer\Desktop\NameSpace\{CLSID}` key. On 25H2, Explorer re-injects Home from a fallback shell registration whenever the namespace tree rebuilds (which `SHChangeNotify` triggers on any file/folder mutation). The re-injected entry lacks the user's `SortOrderIndex`, so it lands in the tail position — below This PC and Network.

## Fix

Switched Home and Gallery from the single-key-delete approach to the three-surface Libraries pattern, applied on both CLSIDs (`{f874310e-…}` / `{e88865ea-…}`):

1. `HKCU\Software\Classes\CLSID\{CLSID}\System.IsPinnedToNameSpaceTree`
2. `HKLM\…\Policies\NonEnum\{CLSID}`
3. `HKLM\…\Explorer\Desktop\NameSpace\{CLSID}\HiddenByDefault`

Each `EnabledValue` array carries the `null` sentinel so the absent-keys default state on 25H2 (where Microsoft no longer ships the `Desktop\NameSpace\{CLSID}` entry by default) correctly detects as "shown".

## Notes

- Verified on Windows 11 25H2 build 26200.x — toggle state now matches Explorer pane reality, and hiding survives namespace-tree rebuilds.
- One-time UX papercut for users who previously hid via the old single-key-delete on 24H2: their toggle will read ON until they toggle OFF once, which writes the proper three surfaces.
- 3D Objects is unaffected — it lives under \`Explorer\MyComputer\NameSpace\` (This PC), not the sidebar registration path.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*