### PR TITLE
Fix: Cancel in Review Mode no longer clears app selections

### DIFF
--- a/src/Winhance.UI/Features/Common/Services/ConfigReviewOrchestrationService.cs
+++ b/src/Winhance.UI/Features/Common/Services/ConfigReviewOrchestrationService.cs
@@ -309,13 +309,15 @@ public class ConfigReviewOrchestrationService : IConfigReviewOrchestrationServic
     {
         if (!_configReviewModeService.IsInReviewMode) return;
 
-        // Clear app selections that were set during EnterReviewModeAsync
-        await _configAppSelectionService.ClearWindowsAppsSelectionAsync();
-
-        _vmCoordinator.ClearExternalAppSelections();
+        // Preserve app selections on cancel — only exit review mode.
+        // Clearing selections was destructive: users who imported a config and clicked
+        // Cancel would lose all their carefully chosen checkboxes in Software & Apps.
+        // Cancel means "cancel the review operation", not "discard my selections".
+        // Review diffs and badges are still cleaned up via ReviewModeExitedEvent
+        // fired by ExitReviewMode() through OnReviewModeChanged.
 
         _configReviewModeService.ExitReviewMode();
-        _logService.Log(LogLevel.Info, "Review mode cancelled - all selections cleared");
+        _logService.Log(LogLevel.Info, "Review mode cancelled - selections preserved");
     }
 
     private UnifiedConfigurationFile BuildFilteredConfigFromApprovals(

--- a/tests/Winhance.UI.Tests/Services/ConfigReviewOrchestrationServiceTests.cs
+++ b/tests/Winhance.UI.Tests/Services/ConfigReviewOrchestrationServiceTests.cs
@@ -485,17 +485,18 @@ public class ConfigReviewOrchestrationServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CancelReviewModeAsync_WhenInReviewMode_ClearsSelectionsAndExits()
+    public async Task CancelReviewModeAsync_WhenInReviewMode_PreservesSelectionsAndExits()
     {
         _mockConfigReviewModeService.Setup(r => r.IsInReviewMode).Returns(true);
 
         var service = CreateService();
         await service.CancelReviewModeAsync();
 
+        // Cancel should exit review mode without clearing selections
         _mockConfigAppSelectionService.Verify(
             s => s.ClearWindowsAppsSelectionAsync(),
-            Times.Once);
-        _mockVmCoordinator.Verify(v => v.ClearExternalAppSelections(), Times.Once);
+            Times.Never);
+        _mockVmCoordinator.Verify(v => v.ClearExternalAppSelections(), Times.Never);
         _mockConfigReviewModeService.Verify(r => r.ExitReviewMode(), Times.Once);
     }
 


### PR DESCRIPTION
## Description

Clicking Cancel in Config Review Mode was destroying all the user's checkbox selections in Software & Apps (both Windows Apps and External Apps). The user expected Cancel to just exit the review operation, not discard their selections.

The fix removes the two selection-clearing calls (`ClearWindowsAppsSelectionAsync()` and `ClearExternalAppSelections()`) from `CancelReviewModeAsync()`. Only `ExitReviewMode()` is called, which still properly cleans up review diffs and badges via the existing `ReviewModeExitedEvent` flow.

**Decision logic:**
- Cancel means "cancel the review operation", not "discard my selections"
- Review state (diffs, badges) is still cleaned up via `ReviewModeExitedEvent` triggered by `ExitReviewMode()` then `OnReviewModeChanged`
- Preserved selections are harmless — they are just checkboxes with no side effects until Apply is clicked
- If the user wants to clear selections, they can do so via the existing UI

| Action | Before | After |
|--------|--------|-------|
| Cancel | Clear all selections + exit review mode | Exit review mode only (selections preserved) |
| Apply | Execute selections + exit review mode | Unchanged |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #656

## Testing Performed

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Regression testing performed

**Manual test:** Traced the full cancel flow through `ReviewModeBarViewModel.CancelReviewModeAsync()` then `ConfigurationService.CancelReviewModeAsync()` then `ConfigReviewOrchestrationService.CancelReviewModeAsync()` then `ExitReviewMode()`, verified that `OnReviewModeChanged` still publishes `ReviewModeExitedEvent` which cleans up review diffs/badges on all SettingItemViewModels. Confirmed no other code paths depend on the selection-clearing behavior during cancel.

**Unit tests:** All 22 `ConfigReviewOrchestrationServiceTests` pass locally (Passed: 22, Failed: 0).

**Regression — full test suite results:** 6204 passed, 7 failed. The 7 failures are all pre-existing and unrelated to this change:
- 4x `AppItemViewModelTests.IconSource_*` — WinRT COM exception (requires UI thread, headless runner limitation)
- 1x `SettingItemViewModelTests.BadgeRow_*` — pre-existing badge logic test
- 1x `SettingCatalogValidatorTests.Selection_*` — pre-existing catalog validation
- 1x `SettingStateSnapshotTests.SettingStateBaseline_*` — pre-existing baseline mismatch

None of these touch `ConfigReviewOrchestrationService` or the cancel flow.

## Screenshots/Videos

N/A — behavioral fix, no visual changes.

## Checklist

- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The existing test `CancelReviewModeAsync_WhenInReviewMode_ClearsSelectionsAndExits` was renamed to `CancelReviewModeAsync_WhenInReviewMode_PreservesSelectionsAndExits` and now verifies that `ClearWindowsAppsSelectionAsync()` and `ClearExternalAppSelections()` are **never** called on cancel, confirming selections are preserved.
