### PR TITLE
Add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: memstechtips
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: memstechtips


### PR DESCRIPTION
Adds the GitHub Sponsors link (`github: memstechtips`) to `.github/FUNDING.yml`.

GitHub renders the repo's **Sponsor** button from `FUNDING.yml` on the **default branch** (`main`), so this targets `main` directly. The same change is already on `dev`. Only the funding file changes here — nothing else.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*