### PR TITLE
sponsors: per-tier card data + perk swap — contact on silver+, website link on gold+ (data-only)

### DIFF
--- a/sponsors/README.md
+++ b/sponsors/README.md
@@ -30,8 +30,8 @@ bundled with every release and used as the **offline fallback** when the fetch f
       "tier": "gold",                // bronze | silver | gold | emerald
       "city": "Austin, TX",          // shown on the card
       "country": "US",
-      "contact": "contact@yourit.com", // optional; shown on gold/emerald cards
-      "url": "https://www.yourit.com", // clickable on silver and up
+      "contact": "contact@yourit.com", // optional; shown on silver and up
+      "url": "https://www.yourit.com", // clickable on gold and up
       "logo": "logos/your-it.png",   // square, ideally 512x512 PNG, transparent or dark-friendly
       "since": "2026-06",
       "example": true                // OPTIONAL: renders with an "Example — this could
@@ -72,16 +72,16 @@ tier is identifiable by the same color everywhere.
 - **winhance.net download page:** the same top-**6** box (or as many as the space
   fits), with a **"View all sponsors"** link to the store wall. No carousel.
 - **In-app sponsors page:** business sponsors only, same order, same tier colors.
-- **Card contents by tier:** every card shows logo, name, city; the website link
-  renders on silver and up; the contact line on gold and up.
+- **Card contents by tier:** every card shows logo, name, city; the contact line
+  renders on silver and up; the clickable website link on gold and up.
 
 ### Tier → surface mapping
 
 | Tier | Sponsors pages (store + winhance.net) | winhance.net download-page showcase | In-app sponsors page | Release notes |
 |---|---|---|---|---|
 | bronze | logo + name | — | — | — |
-| silver | ✓ | full card (logo, city, link) | — | — |
-| gold | ✓ | ✓ | full card (logo, city, contact, link) | mention |
+| silver | ✓ | full card (logo, city, contact) | — | — |
+| gold | ✓ | ✓ + website link | full card (logo, city, contact, link) | mention |
 | emerald | first position | first position | first position | mention |
 
 Individual **supporters** appear on the web supporters wall only — never in the app.
@@ -116,8 +116,8 @@ Individual **supporters** appear on the web supporters wall only — never in th
 
 1. Drop the square logo into `logos/` named `<id>.png`.
 2. Add the entry to `sponsors.json`, bump `updated`. **Only include the fields the
-   tier promises** — bronze: `logo` + `name` only; silver: + `city` + `url`;
-   gold/emerald: + `contact`. (`id`, `tier`, `country`, `since` are always present;
+   tier promises** — bronze: `logo` + `name` only; silver: + `city` + `contact`;
+   gold/emerald: + `url`. (`id`, `tier`, `country`, `since` are always present;
    renderers also gate by tier as defense in depth, but the data itself must not
    carry more than the sponsor paid for.)
 3. Open a data-only PR into `main`.

--- a/sponsors/README.md
+++ b/sponsors/README.md
@@ -115,5 +115,9 @@ Individual **supporters** appear on the web supporters wall only — never in th
 ## Adding a sponsor
 
 1. Drop the square logo into `logos/` named `<id>.png`.
-2. Add the entry to the right array in `sponsors.json`, bump `updated`.
+2. Add the entry to `sponsors.json`, bump `updated`. **Only include the fields the
+   tier promises** — bronze: `logo` + `name` only; silver: + `city` + `url`;
+   gold/emerald: + `contact`. (`id`, `tier`, `country`, `since` are always present;
+   renderers also gate by tier as defense in depth, but the data itself must not
+   carry more than the sponsor paid for.)
 3. Open a data-only PR into `main`.

--- a/sponsors/sponsors.json
+++ b/sponsors/sponsors.json
@@ -20,7 +20,6 @@
       "tier": "silver",
       "city": "WC, ZA",
       "country": "ZA",
-      "contact": "contact@memstechtips.com",
       "url": "https://github.com/memstechtips/UnattendedWinstall",
       "logo": "logos/unattendedwinstall.png",
       "since": "2026-06",
@@ -30,10 +29,7 @@
       "id": "memstechtips",
       "name": "Memstechtips",
       "tier": "bronze",
-      "city": "WC, ZA",
       "country": "ZA",
-      "contact": "contact@memstechtips.com",
-      "url": "https://www.memstechtips.com",
       "logo": "logos/memstechtips.png",
       "since": "2026-06",
       "example": true

--- a/sponsors/sponsors.json
+++ b/sponsors/sponsors.json
@@ -20,7 +20,7 @@
       "tier": "silver",
       "city": "WC, ZA",
       "country": "ZA",
-      "url": "https://github.com/memstechtips/UnattendedWinstall",
+      "contact": "contact@memstechtips.com",
       "logo": "logos/unattendedwinstall.png",
       "since": "2026-06",
       "example": true


### PR DESCRIPTION
Data-only PR per `sponsors/README.md` rules — touches only the `sponsors/` folder. Two commits, the first of which just missed the #686 merge window:

1. **Per-tier data trim** — each entry carries only the fields its tier promises. Currently `main` still holds full contact/url data on the silver and bronze examples; the store's renderer is gating it client-side, but the data itself shouldn't carry more than the sponsor paid for.
2. **Perk swap (Marco's call, 2026-06-11):** contact details now render on **silver and up**; the clickable website link is a **gold-and-up** perk (was the other way around). The silver example card swaps its url for a contact line; README rules and tier matrix updated.

Resulting example data: gold = logo, name, city, contact, link · silver = logo, name, city, contact · bronze = logo, name.

The store theme (v1.4.9) deploys the matching render rules and ladder copy in the same pass.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*