### PR TITLE
sponsors: README — data home moved to the dedicated sponsors branch (data-only)

### DIFF
--- a/sponsors/README.md
+++ b/sponsors/README.md
@@ -11,12 +11,32 @@ across every surface that shows it:
 There is **one unified sponsor space per surface** — no separate "Top Sponsors"
 box or carousel. Emerald sponsors simply sort first and carry emerald styling.
 
-## How the app consumes it
+## Where the live data lives — the `sponsors` branch
 
-Winhance fetches the live file from the `main` branch
-(`https://raw.githubusercontent.com/memstechtips/Winhance/main/sponsors/sponsors.json`)
-so new sponsors appear in the app without a release. A snapshot of this folder is
-bundled with every release and used as the **offline fallback** when the fetch fails.
+**This data's home is the dedicated `sponsors` branch** (an orphan branch holding
+only this folder), not `main`. Every consumer fetches from it:
+
+```
+https://raw.githubusercontent.com/memstechtips/Winhance/sponsors/sponsors/sponsors.json
+```
+
+New sponsors and supporters appear on every surface without a release. A snapshot
+of this folder (from the `sponsors` branch) is bundled with every release and used
+as the **offline fallback** when the fetch fails. `main` keeps a copy of the README
+for discoverability; the branch is authoritative for data.
+
+### How updates happen
+
+- **Individual supporters: automated.** A scheduled job (`sponsors-sync`, every
+  6 hours on the agent box) reads new paid store orders, finds the supporters-wall
+  opt-in, normalises the name to "First L.", dedupes, prepends (newest first) and
+  pushes here. Names are treated as untrusted data: sanitised, length-capped,
+  rendered as text only.
+- **Business sponsors: never automated.** The job detects a sponsor-tier purchase
+  and notifies Marco; the card (logo arrives by email) is added here only after
+  Marco approves it.
+- Marco edits via PR or direct push; the agent pushes data-only commits as
+  Memory's Agent.
 
 ## Schema (`sponsors.json`)
 


### PR DESCRIPTION
Documentation-only change to `sponsors/README.md` on `main`, reflecting today's infrastructure decision (Marco-approved):

- The live data home is now the dedicated orphan **`sponsors` branch** (holds only the `sponsors/` folder). All surfaces fetch `https://raw.githubusercontent.com/memstechtips/Winhance/sponsors/sponsors/sponsors.json` — the store wall already does.
- **Individual supporter opt-ins are automated:** the `sponsors-sync` job on the agent box runs every 6 hours, reads paid store orders, and publishes sanitised "First L." names to the branch (newest first).
- **Business sponsor cards are never auto-published** — a sponsor-tier order creates a Mission Control flag + push notification, and the card goes live only after Marco approves it.
- Release bundles snapshot the `sponsors/` folder from the `sponsors` branch.

`main`'s copy of the folder stays as documentation/discoverability; the branch is authoritative for data.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*