### PR TITLE
sponsors: main's README becomes a pointer to the sponsors branch (data-only, final)

### DIFF
--- a/sponsors/README.md
+++ b/sponsors/README.md
@@ -1,143 +1,20 @@
 # Winhance Sponsors & Supporters Data
 
-This folder is the **single source of truth** for sponsor and supporter recognition
-across every surface that shows it:
+**The live data and the authoritative documentation live on the dedicated
+[`sponsors` branch](https://github.com/memstechtips/Winhance/tree/sponsors/sponsors)**
+— an orphan branch holding only this folder, updated continuously (supporter
+opt-ins automated via the sponsors-sync job; business sponsor cards added after
+Marco's approval).
 
-- the **in-app sponsors page** in Winhance (business sponsors only — never individual names),
-- the sponsor showcase on the **winhance.net** download page,
-- the sponsors & supporters wall on **store.memstechtips.com/winhance/**,
-- the sponsors line in **release notes**.
-
-There is **one unified sponsor space per surface** — no separate "Top Sponsors"
-box or carousel. Emerald sponsors simply sort first and carry emerald styling.
-
-## Where the live data lives — the `sponsors` branch
-
-**This data's home is the dedicated `sponsors` branch** (an orphan branch holding
-only this folder), not `main`. Every consumer fetches from it:
+Every surface fetches from the branch:
 
 ```
 https://raw.githubusercontent.com/memstechtips/Winhance/sponsors/sponsors/sponsors.json
 ```
 
-New sponsors and supporters appear on every surface without a release. A snapshot
-of this folder (from the `sponsors` branch) is bundled with every release and used
-as the **offline fallback** when the fetch fails. `main` keeps a copy of the README
-for discoverability; the branch is authoritative for data.
-
-### How updates happen
-
-- **Individual supporters: automated.** A scheduled job (`sponsors-sync`, every
-  6 hours on the agent box) reads new paid store orders, finds the supporters-wall
-  opt-in, normalises the name to "First L.", dedupes, prepends (newest first) and
-  pushes here. Names are treated as untrusted data: sanitised, length-capped,
-  rendered as text only.
-- **Business sponsors: never automated.** The job detects a sponsor-tier purchase
-  and notifies Marco; the card (logo arrives by email) is added here only after
-  Marco approves it.
-- Marco edits via PR or direct push; the agent pushes data-only commits as
-  Memory's Agent.
-
-## Schema (`sponsors.json`)
-
-```jsonc
-{
-  "updated": "YYYY-MM-DD",
-  "sponsors": [
-    {
-      "id": "your-it",               // slug, unique; logo filename derives from it
-      "name": "Your IT",
-      "tier": "gold",                // bronze | silver | gold | emerald
-      "city": "Austin, TX",          // shown on the card
-      "country": "US",
-      "contact": "contact@yourit.com", // optional; shown on silver and up
-      "url": "https://www.yourit.com", // clickable on gold and up
-      "logo": "logos/your-it.png",   // square, ideally 512x512 PNG, transparent or dark-friendly
-      "since": "2026-06",
-      "example": true                // OPTIONAL: renders with an "Example — this could
-                                     // be you" badge; omit for real sponsors
-    }
-  ],
-  "supporters": [
-    { "name": "Marco d.", "since": "2026-06" }  // individuals, OPT-IN, names only
-  ]
-}
-```
-
-The `supporters` array is maintained **newest donation first** — a returning
-donor's entry moves back to the top (`since` stays their first donation).
-Renderers display it in array order. The legacy `topSponsors` array is retired:
-Emerald sponsors live in `sponsors` with `"tier": "emerald"`.
-
-### Tier colors (canonical — every surface uses these exact values)
-
-| Tier | Hex | Use |
-|---|---|---|
-| bronze | `#CD7F32` | card border + tier label |
-| silver | `#AEB6C2` | card border + tier label |
-| gold | `#FFD700` | card border + tier label (matches the brand gold) |
-| emerald | `#50C878` | card border + tier label, with a subtle glow |
-
-The store theme defines these as CSS variables (`--tier-bronze` …); winhance.net
-and the WinUI 3 in-app sponsors page must use the same hex values so a sponsor's
-tier is identifiable by the same color everywhere.
-
-### Display rules (all surfaces)
-
-- **Order:** emerald → gold → silver → bronze; array order is kept within a tier.
-- **Store wall** (`store.memstechtips.com/winhance/`): shows the top **6** cards,
-  then a **"See all sponsors"** button expands the full wall in place. Individual
-  supporters render below in their own strip, newest first, capped at **150**
-  with a "most recent" note when truncated. Business sponsors are never capped.
-- **winhance.net download page:** the same top-**6** box (or as many as the space
-  fits), with a **"View all sponsors"** link to the store wall. No carousel.
-- **In-app sponsors page:** business sponsors only, same order, same tier colors.
-- **Card contents by tier:** every card shows logo, name, city; the contact line
-  renders on silver and up; the clickable website link on gold and up.
-
-### Tier → surface mapping
-
-| Tier | Sponsors pages (store + winhance.net) | winhance.net download-page showcase | In-app sponsors page | Release notes |
-|---|---|---|---|---|
-| bronze | logo + name | — | — | — |
-| silver | ✓ | full card (logo, city, contact) | — | — |
-| gold | ✓ | ✓ + website link | full card (logo, city, contact, link) | mention |
-| emerald | first position | first position | first position | mention |
-
-Individual **supporters** appear on the web supporters wall only — never in the app.
-
-## Lifecycle: one-time, lapsed, and past sponsors
-
-- **Individual supporters are permanent.** A thank-you doesn't expire — one-time or
-  recurring makes no difference. `since` = the date of their (first) donation. There
-  is no "past supporters" section.
-- **Business sponsor cards are active inventory.** The paid surfaces (download-page
-  showcase, in-app page, first-position placement) belong to *active* sponsorships: a monthly that
-  cancels, or a 1-year purchase that isn't renewed, lapses. Set the optional
-  `"until": "YYYY-MM"` field on the entry — renderers must then drop the card from
-  all paid surfaces and show the sponsor as a **name-only line in a "Past sponsors"
-  list on the web sponsors page only** (no logo, no link, not in-app). Gratitude is
-  permanent; ad placement is for current sponsors.
-- A 1-year sponsorship is active until 12 months after `since`; give a grace period
-  before setting `until` (renewal conversations happen by email, not by cron).
-- Removal on request still overrides everything, including the past-sponsors list.
-
-## Hard rules
-
-1. **Never** record or publish amounts, totals, or counts — names/logos and dates only.
-2. Everything here is **opt-in**. Remove anyone on request, immediately.
-3. Every surface that renders this data must carry the disclaimer:
-   *"Sponsors support Winhance's development. A listing recognises that support —
-   it is not an endorsement by Winhance of any sponsor's products or services."*
-4. Updates are **data-only commits**: this folder only, nothing else in the same
-   commit. They go to `main` via PR (Marco merges).
-
-## Adding a sponsor
-
-1. Drop the square logo into `logos/` named `<id>.png`.
-2. Add the entry to `sponsors.json`, bump `updated`. **Only include the fields the
-   tier promises** — bronze: `logo` + `name` only; silver: + `city` + `contact`;
-   gold/emerald: + `url`. (`id`, `tier`, `country`, `since` are always present;
-   renderers also gate by tier as defense in depth, but the data itself must not
-   carry more than the sponsor paid for.)
-3. Open a data-only PR into `main`.
+Release bundles snapshot the folder **from the `sponsors` branch** as the offline
+fallback. The copy of `sponsors.json` and `logos/` here on `main` is a stale
+point-in-time snapshot kept only so the folder is discoverable — do not edit it,
+do not consume it. Schema, tier rules, colors, display caps, and the hard rules
+(no amounts ever, opt-in only, the disclaimer) are all documented in the README
+on the `sponsors` branch.


### PR DESCRIPTION
One small change, and it should be the **last** sponsors README PR ever: `main`'s `sponsors/README.md` becomes a short pointer to the `sponsors` branch.

**Why:** the branch is already authoritative for data and docs; keeping a full README copy on `main` meant a sync PR after every wording change — and your merge speed beat my pushes three times today, each time silently orphaning a commit. A pointer can't go stale, so nothing will need syncing again.

The pointer also clarifies that `main`'s `sponsors.json` + `logos/` are a non-authoritative snapshot kept only for discoverability, and that release bundles snapshot from the `sponsors` branch.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*