### PR TITLE
fix(ui): swap transposed table and compact view icons

### DIFF
--- a/src/Winhance.UI/Features/SoftwareApps/SoftwareAppsPage.xaml
+++ b/src/Winhance.UI/Features/SoftwareApps/SoftwareAppsPage.xaml
@@ -808,7 +808,7 @@
                                   BorderThickness="0"
                                   CornerRadius="0"
                                   Padding="10,6">
-                        <fluentIcons:FluentIcon Icon="TableSimple" IconVariant="Regular" FontSize="18"/>
+                        <fluentIcons:FluentIcon Icon="LineHorizontal3" IconVariant="Regular" FontSize="18"/>
                     </ToggleButton>
                     <ToggleButton x:Name="CompactViewToggle"
                                   IsChecked="{x:Bind ViewModel.IsCompactView, Mode=OneWay}"
@@ -819,7 +819,7 @@
                                   BorderThickness="0"
                                   CornerRadius="0,4,4,0"
                                   Padding="10,6">
-                        <fluentIcons:FluentIcon Icon="LineHorizontal3" IconVariant="Regular" FontSize="18"/>
+                        <fluentIcons:FluentIcon Icon="TableSimple" IconVariant="Regular" FontSize="18"/>
                     </ToggleButton>
                 </StackPanel>
             </Border>


### PR DESCRIPTION
## Summary

Swaps the icons for Table View and Compact View in the Software & Apps page to correct their visual representation.

## Problem

The Table View and Compact View icons were transposed. The Table View (displaying full-width rows) used the grid-like `TableSimple` icon, while the Compact View (displaying a wrapping grid of cells) used the list-like `LineHorizontal3` icon.

## Changes

- **`src/Winhance.UI/Features/SoftwareApps/SoftwareAppsPage.xaml`**: Swapped the `Icon` properties of the `TableViewToggle` (`TableSimple` -> `LineHorizontal3`) and `CompactViewToggle` (`LineHorizontal3` -> `TableSimple`) toggle buttons.

## Related Issues

Fixes #701
