### PR TITLE
fix: document clipboard history dependency

### DIFF
--- a/src/Winhance.Core/Features/Optimize/Models/GamingAndPerformanceOptimizations.cs
+++ b/src/Winhance.Core/Features/Optimize/Models/GamingAndPerformanceOptimizations.cs
@@ -2688,7 +2688,7 @@ public static class GamingAndPerformanceOptimizations
                     Id = "gaming-touch-keyboard-service",
                     IsSubjectivePreference = true,
                     Name = "Touch Keyboard and Handwriting Panel Service",
-                    Description = "Manages the Windows Input Experience including touch keyboard, pen/stylus input, handwriting panel, emoji panel (Win+.), and Xbox controller keyboard. Disabling will break all virtual/software keyboard input but is safe on desktop systems without touchscreen, pen, or gamepad",
+                    Description = "Manages the Windows Input Experience, including the touch keyboard, pen/stylus input, handwriting panel, emoji panel (Win+.), Windows clipboard history (Win+V), and Xbox controller keyboard. Disabling breaks these features and all virtual/software keyboard input",
                     GroupName = "System Services",
                     Icon = "KeyboardOutline",
                     InputType = InputType.Selection,

--- a/src/Winhance.UI/Features/Common/Localization/en.json
+++ b/src/Winhance.UI/Features/Common/Localization/en.json
@@ -1018,7 +1018,7 @@
   "Setting_gaming-biometric-service_Name": "Windows Biometric Service",
   "Setting_gaming-biometric-service_Description": "Enables fingerprint and facial recognition login via Windows Hello. Safe to disable on desktop systems without biometric hardware",
   "Setting_gaming-touch-keyboard-service_Name": "Touch Keyboard and Handwriting Panel Service",
-  "Setting_gaming-touch-keyboard-service_Description": "Manages the Windows Input Experience including touch keyboard, pen/stylus input, handwriting panel, emoji panel (Win+.), and Xbox controller keyboard. Disabling will break all virtual/software keyboard input but is safe on desktop systems without touchscreen, pen, or gamepad",
+  "Setting_gaming-touch-keyboard-service_Description": "Manages the Windows Input Experience, including the touch keyboard, pen/stylus input, handwriting panel, emoji panel (Win+.), Windows clipboard history (Win+V), and Xbox controller keyboard. Disabling breaks these features and all virtual/software keyboard input",
   "Setting_gaming-sensor-monitoring-service_Name": "Sensor Monitoring Service",
   "Setting_gaming-sensor-monitoring-service_Description": "Monitors various sensors like ambient light and orientation. Safe to disable on desktop systems without sensor hardware",
   "Setting_gaming-sensor-data-service_Name": "Sensor Data Service",


### PR DESCRIPTION
## Description

Updates the Touch Keyboard and Handwriting Panel Service description to explicitly state that disabling the service also disables Windows clipboard history (`Win+V`).

The previous wording described the setting as safe on desktop systems without touch, pen, or gamepad hardware. That could mislead desktop users who rely on clipboard history, so the description now lists clipboard history with the other affected Windows Input Experience features.

Both the catalog fallback text and the English UI localization are updated so the warning is visible in the application.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issues

Follow-up to #374 and #590.

## Testing Performed

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [x] Regression testing performed

Validation performed:

- `dotnet build src/Winhance.Core/Winhance.Core.csproj --configuration Release --no-restore` passes with zero warnings.
- All 29 localization JSON files parse successfully and retain the same key set as `en.json`.
- Verified that both the catalog fallback and English UI localization include `Windows clipboard history (Win+V)`.
- `git diff --check` passes.

The localization integration-test project could not be compiled locally because the machine does not have the Windows 10 UAP SDK `10.0.19041.0` Platform.xml required by the unrelated WinGet interop project.

## Screenshots/Videos

Not applicable; this is a text-only clarification.

## Checklist

- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

An earlier source-only wording change for #590 did not update the localized UI string. This change keeps the catalog fallback and the displayed English localization in sync.
