### PR TITLE
fix(registry): refuse DeleteKey on Windows NT descendants

### DIFF
--- a/src/Winhance.Infrastructure/Features/Common/Services/WindowsRegistryService.cs
+++ b/src/Winhance.Infrastructure/Features/Common/Services/WindowsRegistryService.cs
@@ -90,6 +90,8 @@ internal class WindowsRegistryService(ILogService logService, IInteractiveUserSe
     // Prevents accidental deletion of top-level hive branches like HKLM\SOFTWARE.
     private const int MinDeleteDepth = 2;
 
+    // Exact roots only. PolicyCleanup and Explorer KeyExists toggles delete *under*
+    // SOFTWARE\Policies and SOFTWARE\Microsoft\Windows; those descendants must stay allowed.
     internal static readonly HashSet<string> ProtectedSubKeyRoots = new(StringComparer.OrdinalIgnoreCase)
     {
         @"SOFTWARE\Microsoft\Windows",
@@ -99,16 +101,42 @@ internal class WindowsRegistryService(ILogService logService, IInteractiveUserSe
         @"SYSTEM\CurrentControlSet\Services",
     };
 
+    // Recursive DeleteSubKeyTree is never safe under Windows NT (ProfileList, CurrentVersion).
+    // Segment boundary so "Windows NT" does not match the "Windows" exact root.
+    internal static readonly HashSet<string> ProtectedSubKeySubtrees = new(StringComparer.OrdinalIgnoreCase)
+    {
+        @"SOFTWARE\Microsoft\Windows NT",
+        @"SOFTWARE\WOW6432Node\Microsoft\Windows NT",
+    };
+
+    internal static bool IsProtectedSubKeyPath(string subKeyPath)
+    {
+        foreach (var protectedRoot in ProtectedSubKeyRoots)
+        {
+            if (subKeyPath.Equals(protectedRoot, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        foreach (var subtree in ProtectedSubKeySubtrees)
+        {
+            if (subKeyPath.Equals(subtree, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (subKeyPath.StartsWith(subtree + @"\", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
     public bool DeleteKey(string keyPath)
     {
         try
         {
-            if (!KeyExists(keyPath))
-                return true;
+            var (rootKey, operationalSubKeyPath) = ParseKeyPath(keyPath);
+            var protectionPath = HiveRelativeSubKeyPath(keyPath);
 
-            var (rootKey, subKeyPath) = ParseKeyPath(keyPath);
-
-            var segments = subKeyPath.Split('\\', StringSplitOptions.RemoveEmptyEntries);
+            var segments = protectionPath.Split('\\', StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length < MinDeleteDepth)
             {
                 logService.Log(LogLevel.Warning,
@@ -116,17 +144,17 @@ internal class WindowsRegistryService(ILogService logService, IInteractiveUserSe
                 return false;
             }
 
-            foreach (var protectedRoot in ProtectedSubKeyRoots)
+            if (IsProtectedSubKeyPath(protectionPath))
             {
-                if (subKeyPath.Equals(protectedRoot, StringComparison.OrdinalIgnoreCase))
-                {
-                    logService.Log(LogLevel.Warning,
-                        $"[WindowsRegistryService] Refusing to delete protected registry key '{keyPath}'");
-                    return false;
-                }
+                logService.Log(LogLevel.Warning,
+                    $"[WindowsRegistryService] Refusing to delete protected registry key '{keyPath}'");
+                return false;
             }
 
-            rootKey.DeleteSubKeyTree(subKeyPath, false);
+            if (!KeyExists(keyPath))
+                return true;
+
+            rootKey.DeleteSubKeyTree(operationalSubKeyPath, false);
             return true;
         }
         catch (Exception ex)
@@ -455,6 +483,17 @@ internal class WindowsRegistryService(ILogService logService, IInteractiveUserSe
             logService.Log(LogLevel.Error, $"[WindowsRegistryService] Error setting composite key '{compositeKey}' in '{keyPath}\\{valueName}': {ex.Message}");
             return false;
         }
+    }
+
+    // Hive-relative path, ignoring OTS HKCU → HKU\{SID} redirection so the
+    // protected-root check still sees SOFTWARE\... rather than {SID}\SOFTWARE\...
+    private static string HiveRelativeSubKeyPath(string keyPath)
+    {
+        var parts = keyPath.Split('\\', 2);
+        if (parts.Length < 2)
+            throw new ArgumentException($"Invalid registry key path: {keyPath}");
+
+        return parts[1];
     }
 
     private (RegistryKey rootKey, string subKeyPath) ParseKeyPath(string keyPath)

--- a/tests/Winhance.Infrastructure.Tests/Services/WindowsRegistryServiceTests.cs
+++ b/tests/Winhance.Infrastructure.Tests/Services/WindowsRegistryServiceTests.cs
@@ -30,6 +30,7 @@ public class WindowsRegistryServiceTests
 
     [Theory]
     [InlineData(@"HKLM\SOFTWARE\Microsoft\Windows")]
+    [InlineData(@"HKLM\SOFTWARE\Microsoft\Windows NT")]
     [InlineData(@"HKLM\SOFTWARE\Policies")]
     [InlineData(@"HKLM\SYSTEM\CurrentControlSet")]
     [InlineData(@"HKLM\SYSTEM\CurrentControlSet\Services")]
@@ -43,8 +44,43 @@ public class WindowsRegistryServiceTests
     public void ProtectedSubKeyRoots_ContainsExpectedEntries()
     {
         WindowsRegistryService.ProtectedSubKeyRoots.Should().Contain(@"SOFTWARE\Microsoft\Windows");
+        WindowsRegistryService.ProtectedSubKeyRoots.Should().Contain(@"SOFTWARE\Microsoft\Windows NT");
         WindowsRegistryService.ProtectedSubKeyRoots.Should().Contain(@"SYSTEM\CurrentControlSet");
         WindowsRegistryService.ProtectedSubKeyRoots.Should().Contain(@"SOFTWARE\Policies");
+    }
+
+    [Theory]
+    [InlineData(@"SOFTWARE\Microsoft\Windows")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows NT")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList")]
+    [InlineData(@"SOFTWARE\WOW6432Node\Microsoft\Windows NT")]
+    [InlineData(@"SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion")]
+    [InlineData(@"SOFTWARE\Policies")]
+    [InlineData(@"SYSTEM\CurrentControlSet")]
+    [InlineData(@"SYSTEM\CurrentControlSet\Services")]
+    [InlineData(@"software\microsoft\windows nt\currentversion")]
+    public void IsProtectedSubKeyPath_ProtectedRootAndWindowsNtDescendants_ReturnsTrue(string subKeyPath)
+    {
+        WindowsRegistryService.IsProtectedSubKeyPath(subKeyPath).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"SOFTWARE\Winhance")]
+    [InlineData(@"SOFTWARE\Microsoft")]
+    [InlineData(@"SOFTWARE\Microsoft\WindowsPowerShell")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows Defender")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows\CurrentVersion")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}")]
+    [InlineData(@"SOFTWARE\Policies\Microsoft")]
+    [InlineData(@"SOFTWARE\Policies\Microsoft\Windows\DataCollection")]
+    [InlineData(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection")]
+    [InlineData(@"SYSTEM")]
+    [InlineData(@"SYSTEM\ControlSet001")]
+    [InlineData(@"SYSTEM\CurrentControlSet\Services\Winmgmt")]
+    public void IsProtectedSubKeyPath_UnrelatedAndCatalogDeletePaths_ReturnsFalse(string subKeyPath)
+    {
+        WindowsRegistryService.IsProtectedSubKeyPath(subKeyPath).Should().BeFalse();
     }
 
     [Fact]
@@ -53,6 +89,32 @@ public class WindowsRegistryServiceTests
         // Non-existent keys return true (nothing to delete)
         var result = _sut.DeleteKey(@"HKCU\Software\Winhance\TestKey\SubKey");
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeleteKey_NonExistentPolicyPath_ReturnsTrue()
+    {
+        var result = _sut.DeleteKey(@"HKCU\SOFTWARE\Policies\Microsoft\Windows\DataCollection\WinhanceDoesNotExist");
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeleteKey_WindowsNtDescendant_ReturnsFalseEvenWhenMissing()
+    {
+        var result = _sut.DeleteKey(@"HKCU\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinhanceDoesNotExist");
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteKey_WindowsNtDescendant_ReturnsFalseUnderOtsRedirect()
+    {
+        _mockInteractiveUser.Setup(x => x.IsOtsElevation).Returns(true);
+        _mockInteractiveUser.Setup(x => x.InteractiveUserSid).Returns("S-1-5-21-1-2-3-1001");
+
+        var otsSut = new WindowsRegistryService(_mockLog.Object, _mockInteractiveUser.Object);
+        var result = otsSut.DeleteKey(@"HKCU\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinhanceDoesNotExist");
+
+        result.Should().BeFalse();
     }
 
 }

--- a/tests/Winhance.IntegrationTests/Registry/WindowsRegistryServiceTests.cs
+++ b/tests/Winhance.IntegrationTests/Registry/WindowsRegistryServiceTests.cs
@@ -114,6 +114,29 @@ public class WindowsRegistryServiceTests : IDisposable
     }
 
     [Fact]
+    public void DeleteKey_ProtectedDescendant_ReturnsFalseAndLeavesKey()
+    {
+        var leaf = $"WinhanceProtectedDescendantTest_{Guid.NewGuid():N}";
+        var path = $@"HKCU\SOFTWARE\Microsoft\Windows NT\CurrentVersion\{leaf}";
+        var subKeyPath = $@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\{leaf}";
+
+        try
+        {
+            _service.SetValue(path, "Marker", 1, RegistryValueKind.DWord);
+            _service.KeyExists(path).Should().BeTrue();
+
+            var result = _service.DeleteKey(path);
+
+            result.Should().BeFalse();
+            _service.KeyExists(path).Should().BeTrue();
+        }
+        finally
+        {
+            Microsoft.Win32.Registry.CurrentUser.DeleteSubKeyTree(subKeyPath, throwOnMissingSubKey: false);
+        }
+    }
+
+    [Fact]
     public void GetSubKeyNames_ReturnsCreatedKeys()
     {
         var basePath = TestPath("SubKeyTest");


### PR DESCRIPTION
## Summary
- Fixes #739: `DeleteKey` used `Equals` against protected roots, so descendants such as `SOFTWARE\Microsoft\Windows NT\CurrentVersion` could reach `DeleteSubKeyTree`.
- Subtree-protect `SOFTWARE\Microsoft\Windows NT` (and the WOW6432Node twin) with a `\` segment boundary so `Windows NT` does not match the `Windows` exact root.
- Leave `SOFTWARE\Policies` and `SOFTWARE\Microsoft\Windows` as exact-only so PolicyCleanup and Explorer KeyExists folder-GUID deletes still work.
- Check the hive-relative path so OTS HKCU → HKU\{SID} redirection cannot bypass the guard.

## Test plan
- [x] Unit theories for protected roots, Windows NT descendants, catalog/policy delete paths, missing-key policy path, and OTS redirect
- [x] Integration test creates a disposable HKCU descendant under Windows NT CurrentVersion, asserts DeleteKey returns false and the key remains
- [ ] Maintainer: `dotnet test` on `Winhance.Infrastructure.Tests` and `Winhance.IntegrationTests` filtered to `WindowsRegistryService` (this machine has no Windows SDK / CsWinRT build)
